### PR TITLE
Add configuration example file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,42 @@
+# FlashLoan Arbitrage Bot Configuration
+
+# Blockchain Configuration
+RPC_URL=https://polygon-rpc.com
+PRIVATE_KEY=your_wallet_private_key_here
+CONTRACT_ADDRESS=0x_your_deployed_contract_address
+
+# API Keys
+ONEINCH_API_KEY=your_1inch_api_key
+TELEGRAM_BOT_TOKEN=your_telegram_bot_token
+TELEGRAM_CHAT_ID=your_telegram_chat_id
+
+# Bot Configuration
+FLASHLOAN_AMOUNT=5000
+MIN_PROFIT_PERCENT=0.5
+MAX_SLIPPAGE_PERCENT=0.5
+RUN_INTERVAL_SEC=12
+TRAINING_MODE=true
+
+# Security
+JWT_SECRET=your_super_secret_jwt_key_here
+ADMIN_EMAIL=admin@your-domain.com
+ADMIN_PASSWORD=your_secure_admin_password
+
+# Server Configuration
+PORT=3001
+NODE_ENV=production
+FRONTEND_URL=https://your-domain.com
+
+# Database
+DATABASE_PATH=./data/arbitrage.db
+
+# AWS Configuration (for deployment)
+AWS_REGION=us-east-1
+INSTANCE_TYPE=t3.medium
+DOMAIN=your-domain.com
+
+# Token Addresses (Polygon)
+USDC_ADDRESS=0x2791bca1f2de4661ed88a30c99a7a9449aa84174
+USDT_ADDRESS=0xc2132d05d31c914a87c6611c10748aeb04b58e8f
+WETH_ADDRESS=0x7ceb23fd6c7194c47762a3a02b85178c45b9b9a6
+WMATIC_ADDRESS=0x0d500b1d8e8ef31e21c99d1db9a6444d3adf1270


### PR DESCRIPTION
## Summary
- add a new `.env.example` so scripts and docs referencing it work properly

## Testing
- `python3 -m py_compile ai/trainer.py`
- `npm test` in `backend` *(fails: jest not installed)*
- `npm test` in `frontend` *(fails: vitest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684633eebd808328ad04884ef7f05ac9