### PR TITLE
Integrate AI prediction into arbitrage bot

### DIFF
--- a/ai/predictor.py
+++ b/ai/predictor.py
@@ -1,0 +1,31 @@
+#!/usr/bin/env python3
+"""Predict expected profit using trained arbitrage model"""
+import os
+import sys
+import joblib
+
+MODEL_PATH = os.path.join(os.path.dirname(__file__), 'models', 'arbitrage_model.joblib')
+
+def main():
+    try:
+        amount = float(sys.argv[1])
+        slippage = float(sys.argv[2])
+        gas_price = float(sys.argv[3])
+        volatility = float(sys.argv[4])
+    except (IndexError, ValueError):
+        print(0)
+        return
+
+    if not os.path.exists(MODEL_PATH):
+        print(0)
+        return
+
+    try:
+        model = joblib.load(MODEL_PATH)
+        prediction = model.predict([[amount, slippage, gas_price, volatility]])[0]
+        print(float(prediction))
+    except Exception:
+        print(0)
+
+if __name__ == '__main__':
+    main()

--- a/bot/arbitrageBot.js
+++ b/bot/arbitrageBot.js
@@ -2,6 +2,8 @@
 const { ethers } = require('ethers');
 const axios = require('axios');
 const sqlite3 = require('sqlite3').verbose();
+const { spawnSync } = require('child_process');
+const path = require('path');
 require('dotenv').config();
 
 class ArbitrageBot {
@@ -13,6 +15,12 @@ class ArbitrageBot {
             minProfitPercent: parseFloat(process.env.MIN_PROFIT_PERCENT) || 0.5,
             runInterval: parseInt(process.env.RUN_INTERVAL_SEC) || 12
         };
+
+        this.dbPath = process.env.DATABASE_PATH || path.join(__dirname, '..', 'data', 'arbitrage.db');
+        this.modelPath = path.join(__dirname, '..', 'ai', 'models', 'arbitrage_model.joblib');
+        this.db = new sqlite3.Database(this.dbPath, err => {
+            if (err) console.error('SQLite error:', err.message);
+        });
 
         console.log('🤖 Arbitrage Bot initialized');
         console.log(`📊 Training Mode: ${this.config.trainingMode}`);
@@ -35,12 +43,15 @@ class ArbitrageBot {
     async runLoop() {
         while (this.isRunning) {
             try {
-                if (this.config.trainingMode) {
-                    console.log('🧠 Training mode: Scanning opportunities...');
-                    // Training logic here
+                const features = await this.gatherFeatures();
+                const predicted = await this.predictProfit(features);
+                await this.logPrediction(features, predicted);
+
+                if (!this.config.trainingMode && predicted >= this.config.minProfitPercent) {
+                    console.log(`✅ Predicted profit ${predicted.toFixed(2)}% \u2013 executing trade`);
+                    await this.executeTrade(features.amount);
                 } else {
-                    console.log('💰 Production mode: Executing trades...');
-                    // Production logic here
+                    console.log(`❌ Predicted profit ${predicted.toFixed(2)}% below threshold`);
                 }
 
                 await this.sleep(this.config.runInterval * 1000);
@@ -53,6 +64,73 @@ class ArbitrageBot {
 
     sleep(ms) {
         return new Promise(resolve => setTimeout(resolve, ms));
+    }
+
+    async gatherFeatures() {
+        const amount = parseFloat(this.config.flashloanAmount);
+        const slippage = parseFloat(process.env.MAX_SLIPPAGE_PERCENT) || 0.5;
+        const gasPrice = await this.getGasPrice();
+        const volatility = await this.getVolatility();
+        return { amount, slippage, gasPrice, volatility };
+    }
+
+    async getGasPrice() {
+        try {
+            const provider = new ethers.providers.JsonRpcProvider(process.env.RPC_URL);
+            const price = await provider.getGasPrice();
+            return parseFloat(ethers.utils.formatUnits(price, 'gwei'));
+        } catch (err) {
+            console.error('Failed to fetch gas price:', err.message);
+            return 0;
+        }
+    }
+
+    async getVolatility() {
+        try {
+            const res = await axios.get('https://api.binance.com/api/v3/ticker/24hr?symbol=ETHUSDT');
+            return Math.abs(parseFloat(res.data.priceChangePercent));
+        } catch (err) {
+            console.error('Failed to fetch volatility:', err.message);
+            return 0;
+        }
+    }
+
+    async predictProfit(features) {
+        const args = [
+            path.join(__dirname, '..', 'ai', 'predictor.py'),
+            features.amount,
+            features.slippage,
+            features.gasPrice,
+            features.volatility
+        ].map(String);
+        const result = spawnSync('python3', args, { encoding: 'utf8' });
+        if (result.error) {
+            console.error('Prediction error:', result.error.message);
+            return 0;
+        }
+        const value = parseFloat(result.stdout.trim());
+        return isNaN(value) ? 0 : value;
+    }
+
+    async logPrediction(features, profit) {
+        const stmt = this.db.prepare(
+            'INSERT INTO ai_training_data (amount, slippage, gas_price, volatility, profit) VALUES (?, ?, ?, ?, ?)'
+        );
+        stmt.run([
+            features.amount,
+            features.slippage,
+            features.gasPrice,
+            features.volatility,
+            profit
+        ], err => {
+            if (err) console.error('DB insert error:', err.message);
+        });
+        stmt.finalize();
+    }
+
+    async executeTrade(amount) {
+        console.log(`📈 Executing trade with amount $${amount}`);
+        // Placeholder for real trade logic
     }
 
     async stop() {


### PR DESCRIPTION
## Summary
- add Python predictor to read the trained model
- make arbitrage bot call predictor before each trade
- log each prediction to `ai_training_data`
- execute trade only when predicted profit exceeds configured threshold

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846386bd27483289a0d72c8fa12f80e