### PR TITLE
Fix DB close handling in stop

### DIFF
--- a/bot/arbitrageBot.js
+++ b/bot/arbitrageBot.js
@@ -221,10 +221,11 @@ class ArbitrageBot {
 
         this.isRunning = false;
         console.log('🛑 Stopping Arbitrage Bot...');
-        await new Promise(resolve => {
+        await new Promise((resolve, reject) => {
             this.db.close(err => {
                 if (err) {
                     console.error('DB close error:', err.message);
+                    return reject(err);
                 }
                 resolve();
             });


### PR DESCRIPTION
## Summary
- improve async closing logic in `stop()`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6846451e7f1c8328a54d3025b5b6b9fb